### PR TITLE
fix: implement clear_index function for Qdrant collection deletion

### DIFF
--- a/app.py
+++ b/app.py
@@ -49,6 +49,8 @@ SKIP_DIRS = {
     'composer',
     'yarn',
     'npm',
+    'venv',
+    'storage',
     
     # Build outputs and caches
     'dist',
@@ -350,6 +352,14 @@ def collection_exists():
         return response.status_code == 200
     except Exception as e:
         logger.error(f"Error checking collection: {e}")
+        return False
+
+def clear_index():
+    try:
+        response = requests.delete("http://vectorstore:6333/collections/code_chunks")
+        return response.status_code == 200
+    except Exception as e:
+        logger.error(f"Failed to clear index: {e}")
         return False
 
 @app.route('/admin/clear', methods=['POST'])


### PR DESCRIPTION
Implement the missing clear_index function that was causing errors when trying to clear the index manually. The function follows the existing codebase pattern of using direct HTTP requests to the Qdrant server, matching how collection_exists and background_reindex handle collection management.

Also adds venv and storage to skip directories as a minor improvement.